### PR TITLE
Allow Split Schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ var StreetSchema = {
     }
 }
 
-app.post('/street/', validate({body: SteetSchema}), function(req, res) {
+app.post('/street/', validate({body: StreetSchema}), function(req, res) {
     // application code
 });
 ```
@@ -194,6 +194,56 @@ addSchemaProperties({
 });
 ```
 See [jsonschema's how to create custom properties](https://github.com/tdegrunt/jsonschema#custom-properties).
+
+## Complex example, with split schemas and references
+
+```js
+var express = require('express');
+var app = express();
+var validate = require('express-jsonschema').validate;
+
+// Address, to be embedded on Person
+var AddressSchema = {
+    "id": "/SimpleAddress",
+    "type": "object",
+    "properties": {
+        "street": {"type": "string"},
+        "zip": {"type": "string"},
+        "city": {"type": "string"},
+        "state": {"type": "string"},
+        "country": {"type": "string"}
+    }
+};
+
+// Person
+var PersonSchema = {
+    "id": "/SimplePerson",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "address": {"$ref": "/SimpleAddress"}
+    }
+};
+
+app.post('/person/', validate({body: PersonSchema}, [AddressSchema]), function(req, res) {
+    // application code
+});
+```
+
+A valid post body:
+
+```json
+{
+    "name": "Barack Obama",
+    "address": {
+        "street": "1600 Pennsylvania Avenue Northwest",
+        "zip": "20500",
+        "city": "Washington",
+        "state": "DC",
+        "country": "USA"
+    }
+}
+```
 
 ## More documentation on JSON schemas
 

--- a/index.js
+++ b/index.js
@@ -135,7 +135,10 @@ function addSchemaProperties(newProperties) {
    @function validate
 
    @desc Accepts an object where the keys are request properties and the
-         values are their respective schemas.
+         values are their respective schemas.  Optionally, you may provide
+         dependency schemas that are referenced by your schemas using `$ref`
+         (see https://www.npmjs.com/package/jsonschema#complex-example-with-split-schemas-and-references
+         for more details).
 
          Returns a middleware function that validates the given
          request properties when a request is made.  If there is any invalid
@@ -147,11 +150,19 @@ function addSchemaProperties(newProperties) {
    @param {Object} schemas - An object where the keys are request properties
           and the values are their respective schemas.
 
+   @param {Array<Object>} [schemaDependencies] - A list of schemas on which
+          schemas in `schemas` parameter are dependent.  These will be added
+          to the `jsonschema` validator.
+
    @returns {callback} - A middleware function.
 */
 
-function validate(schemas) {
+function validate(schemas, schemaDependencies) {
     var validator = new jsonschema.Validator();
+
+    if (Array.isArray(schemaDependencies)) {
+        schemaDependencies.forEach(validator.addSchema.bind(validator));
+    }
 
     Object.keys(customProperties).forEach(function(attr) {
         validator.attributes[attr] = customProperties[attr];

--- a/test/functional.js
+++ b/test/functional.js
@@ -5,13 +5,24 @@ var request = require('supertest'),
     app = require('./testapp');
 
 require('should');
-describe('A route with validation middlewawre', function() {
+describe('A route with validation middleware', function() {
     it('should respond with a 200 if the posted body is valid', function(done) {
         request(app)
             .post('/user/')
             .send(helpers.getUser())
             .expect(function(response) {
                 response.body.should.eql({id: '1234'});
+            })
+            .expect(200)
+            .end(done);
+    });
+
+    it('should respond with a 200 if the posted body is valid and using split schema', function(done) {
+        request(app)
+            .post('/user/split_schema/')
+            .send(helpers.getUser())
+            .expect(function(response) {
+                response.body.should.eql({id: '1337'});
             })
             .expect(200)
             .end(done);

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -15,6 +15,26 @@ module.exports = {
             }
         }, overrides || {});
     },
+    getAddressSchema: function(overrides) {
+        return merge.recursive(true, {
+            'id': '/AddressSchema',
+            'type': 'object',
+            'properties': {
+                'street': {
+                    'type': 'string',
+                    'required': true
+                },
+                'country': {
+                    'type': 'string',
+                    'required': true
+                },
+                'city': {
+                    'type': 'string',
+                    'required': true
+                }
+            }
+        }, overrides || {});
+    },
     getUserSchema: function(overrides) {
         return merge.recursive(true, {
             'id': '/UserSchema',
@@ -69,7 +89,7 @@ module.exports = {
             firstName: 'Todd',
             lastName: 'Terje',
             email: 'todd@terje.com',
-            adress: {
+            address: {
                 street: '1 Aasta Hansteens vei',
                 country: 'Norway',
                 city: 'Oslo'

--- a/test/testapp.js
+++ b/test/testapp.js
@@ -74,6 +74,22 @@ app.post(
     }
 );
 
+app.post(
+    '/user/split_schema/',
+    validate({
+        body: helpers.getUserSchema({
+            properties: {
+                address: {'$ref': '/AddressSchema'}
+            }
+        })
+    }, [helpers.getAddressSchema()]),
+    function(req, res) {
+        res.json({
+            id: '1337'
+        });
+    }
+);
+
 /****** Setup validation handler **************/
 
 app.use(function(err, req, res, next) {
@@ -89,4 +105,3 @@ app.use(function(err, req, res, next) {
 });
 
 module.exports = app;
-


### PR DESCRIPTION
- Allow middleware creator to specify dependency schemas for split schemas
- Use `addSchema` method to provide dependencies to target schema for validation
