### PR TITLE
TravisCI:  Test against node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
-  - "0.11"
+  - "0.12"
 matrix:
-  allow_failures:
-    - node_js: "0.11"
   fast_finish: true
 before_install:
   - npm update -g npm


### PR DESCRIPTION
Some folks are probably using node 0.12 in prod now, so good to test on CI =-D

Random note: it's also reasonably easy to get npm publishing automated on Travis - http://docs.travis-ci.com/user/deployment/npm/
