### PR TITLE
Bugfix for validate()

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,9 @@ function validate(schemas, schemaDependencies) {
     var validator = new jsonschema.Validator();
 
     if (Array.isArray(schemaDependencies)) {
-        schemaDependencies.forEach(validator.addSchema.bind(validator));
+        for(var i = 0; i < schemaDependencies.length; i++) {
+            validator.addSchema(schemaDependencies[i]);
+        }
     }
 
     Object.keys(customProperties).forEach(function(attr) {


### PR DESCRIPTION
When using the schema dependencies, I got the exception: 

TypeError: Parameter 'url' must be a string, not number
    at Url.parse (url.js:107:11)
    at urlParse (url.js:101:5)
    at Object.urlResolve [as resolve](url.js:404:10)
    at Validator.addSubSchema (/.../node_modules/express-jsonschema/node_modules/jsonschema/lib/validator.js:61:36)
    at Validator.addSchema (/.../node_modules/express-jsonschema/node_modules/jsonschema/lib/validator.js:42:8)
    at Array.forEach (native)
    at validate (/.../node_modules/express-jsonschema/index.js:164:28)
    at Object.<anonymous>
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)

This is caused by: schemaDependencies.forEach(callBack) 
-> The callback takes element value, index, and array. This gets bind to the addSchema function, which will lead to a wrong uri.
As can be seen from the original implementation of the addSchema function: 

https://github.com/tdegrunt/jsonschema/blob/master/lib/validator.js#L37

Changing this to a normal for-loop fixes the issue.
