### PR TITLE
Fix for adding schema dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,9 @@ function validate(schemas, schemaDependencies) {
     var validator = new jsonschema.Validator();
 
     if (Array.isArray(schemaDependencies)) {
-        schemaDependencies.forEach(validator.addSchema.bind(validator));
+        schemaDependencies.forEach(function(schema){
+            validator.addSchema(schema);
+        });
     }
 
     Object.keys(customProperties).forEach(function(attr) {


### PR DESCRIPTION
`validator.addSchema(schema, uri)` accepts uri as second parameter and `forEach` provides index. `addSchema` tries to validate uri as URL and we get:
`uncaughtException: Parameter 'url' must be a string, not number`
