### PR TITLE
Fixed wrong variable name for custom validators in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ schemas. It should be called once at the beginning of your application so that y
 have the custom properties available.
 
 ```javascript
-var addAttributes = require('express-jsonschema').addSchemaProperties;
+var addSchemaProperties = require('express-jsonschema').addSchemaProperties;
 
 addSchemaProperties({
     contains: function(value, schema){


### PR DESCRIPTION
The variable name was wrong and required figuring out why it does not work from the scratch :)
