### PR TITLE
Fix test - JSONSchema returns double quotes in validation result string

### DIFF
--- a/test/functional.js
+++ b/test/functional.js
@@ -81,7 +81,7 @@ describe('A route with validation middleware', function() {
                         body: [{
                             value: 'junk',
                             messages: [
-                                'does not conform to the \'email\' format',
+                                'does not conform to the "email" format',
                                 'does not meet minimum length of 7',
                                 'does not contain the string "terje.com"'
                             ],


### PR DESCRIPTION
The test was not passing because JSONSchema returns different validation message - using double quotes instead of single ones
